### PR TITLE
Fix Split Vector2 Missing

### DIFF
--- a/SERE/Nodes/SplitMergeNodes.cpp
+++ b/SERE/Nodes/SplitMergeNodes.cpp
@@ -554,7 +554,7 @@ std::vector<std::shared_ptr<ImFlow::PinProto>> HSVToColorNode::GetPinInfo() {
 }
 
 void AddSplitMergeNodes(NodeEditor& editor) {
-	editor.AddNodeType<MergeFloat2Node>();
+	editor.AddNodeType<SplitFloat2Node>();
 	editor.AddNodeType<MergeFloat2Node>();
 	editor.AddNodeType<SplitFloat3Node>();
 	editor.AddNodeType<MergeFloat3Node>();


### PR DESCRIPTION
Change the duplicate merge node type to a split node to fix the split not being missing for the type vector 2.