### PR TITLE
Add Conditional Nodes

### DIFF
--- a/SERE/CMakeLists.txt
+++ b/SERE/CMakeLists.txt
@@ -47,7 +47,7 @@ add_executable (SERE
 	"Nodes/GlobalNodes.cpp"
 	
 	"ThirdParty/DDSTextureLoader11.cpp"
-	 "RuiNodeEditor/RuiBaseNode.cpp" "RuiNodeEditor/RuiExportPrototype.h" "RuiNodeEditor/RuiVariables.h" "RuiNodeEditor/RuiExportPrototype.cpp")
+	 "RuiNodeEditor/RuiBaseNode.cpp" "RuiNodeEditor/RuiExportPrototype.h" "RuiNodeEditor/RuiVariables.h" "RuiNodeEditor/RuiExportPrototype.cpp" "Nodes/ConditionalNodes.h" "Nodes/ConditionalNodes.cpp")
 
 target_include_directories(SERE PUBLIC CMAKE_CURRENT_SOURCE_DIR )
 target_link_libraries(SERE PUBLIC nfd)

--- a/SERE/Nodes/ConditionalNodes.cpp
+++ b/SERE/Nodes/ConditionalNodes.cpp
@@ -1,0 +1,576 @@
+
+
+#include "Nodes/ConditionalNodes.h"
+
+GreaterNode::GreaterNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const FloatVariable& a = getInVal<FloatVariable>("A");
+		const FloatVariable& b = getInVal<FloatVariable>("B");
+		std::string name = (a.IsConstant() && b.IsConstant()) ? "" : outName;
+
+		return BoolVariable(a.value > b.value, name);
+
+		});
+
+}
+
+GreaterNode::GreaterNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :GreaterNode(rend, style) {}
+
+
+void GreaterNode::draw() {
+	const FloatVariable& a = getInVal<FloatVariable>("A");
+	const FloatVariable& b = getInVal<FloatVariable>("B");
+	ImGui::Text("A %f", a.value);
+	ImGui::Text("B %f", b.value);
+	if (a.value > b.value)
+		ImGui::Text("Res True");
+	else
+		ImGui::Text("Res False");
+}
+
+void GreaterNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void GreaterNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<FloatVariable>("A");
+	const auto& b = getInVal<FloatVariable>("B");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} = {} > {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = {} > {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> GreaterNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("A", ImFlow::ConnectionFilter::SameType(), FloatVariable(0.f)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("B", ImFlow::ConnectionFilter::SameType(), FloatVariable(2.f)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+LessNode::LessNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const FloatVariable& a = getInVal<FloatVariable>("A");
+		const FloatVariable& b = getInVal<FloatVariable>("B");
+		std::string name = (a.IsConstant() && b.IsConstant()) ? "" : outName;
+
+		return BoolVariable(a.value < b.value, name);
+
+		});
+
+}
+
+LessNode::LessNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :LessNode(rend, style) {}
+
+
+void LessNode::draw() {
+	const FloatVariable& a = getInVal<FloatVariable>("A");
+	const FloatVariable& b = getInVal<FloatVariable>("B");
+	ImGui::Text("A %f", a.value);
+	ImGui::Text("B %f", b.value);
+	if (a.value < b.value)
+		ImGui::Text("Res True");
+	else
+		ImGui::Text("Res False");
+}
+
+void LessNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void LessNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<FloatVariable>("A");
+	const auto& b = getInVal<FloatVariable>("B");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} = {} < {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = {} < {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> LessNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("A", ImFlow::ConnectionFilter::SameType(), FloatVariable(0.f)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("B", ImFlow::ConnectionFilter::SameType(), FloatVariable(2.f)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+ConditionalFloatNode::ConditionalFloatNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<FloatVariable>("Res")->behaviour([this, outName]() {
+
+		const BoolVariable& a = getInVal<BoolVariable>("A");
+		const FloatVariable& b = getInVal<FloatVariable>("B");
+		const FloatVariable& c = getInVal<FloatVariable>("C");
+
+		std::string name = (a.IsConstant() && b.IsConstant() && c.IsConstant()) ? "" : outName;
+
+		if (a.value)
+			return FloatVariable(b.value, name);
+		else
+			return FloatVariable(c.value, name);
+
+		});
+
+}
+
+ConditionalFloatNode::ConditionalFloatNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :ConditionalFloatNode(rend, style) {}
+
+
+void ConditionalFloatNode::draw() {
+	const BoolVariable& a = getInVal<BoolVariable>("A");
+
+	const FloatVariable& b = getInVal<FloatVariable>("B");
+	const FloatVariable& c = getInVal<FloatVariable>("C");
+
+	if (a.value)
+		ImGui::Text("In True");
+	else
+		ImGui::Text("In False");
+	ImGui::Text("True %f", b.value);
+	ImGui::Text("False %f", c.value);
+
+}
+
+void ConditionalFloatNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void ConditionalFloatNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<FloatVariable>("Res")->val();
+	const auto& a = getInVal<BoolVariable>("A");
+	const auto& b = getInVal<FloatVariable>("B");
+	const auto& c = getInVal<FloatVariable>("C");
+
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name, c.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b, c](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+		{
+			proto.codeLines.push_back(std::format("{} = {}?{}:{};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto), c.GetFormattedName(proto)));
+
+		}
+		else
+			proto.codeLines.push_back(std::format("float {} = {}?{}:{};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto), c.GetFormattedName(proto)));
+
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> ConditionalFloatNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("A", ImFlow::ConnectionFilter::SameType(), BoolVariable(false)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("B", ImFlow::ConnectionFilter::SameType(), FloatVariable(1.f)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("C", ImFlow::ConnectionFilter::SameType(), FloatVariable(2.f)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<FloatVariable>>("Res"));
+	return info;
+}
+
+EqualFloatNode::EqualFloatNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const FloatVariable& a = getInVal<FloatVariable>("A");
+		const FloatVariable& b = getInVal<FloatVariable>("B");
+		std::string name = (a.IsConstant() && b.IsConstant()) ? "" : outName;
+
+		return BoolVariable(a.value == b.value, name);
+
+		});
+
+}
+
+EqualFloatNode::EqualFloatNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :EqualFloatNode(rend, style) {}
+
+
+void EqualFloatNode::draw() {
+	const FloatVariable& a = getInVal<FloatVariable>("A");
+	const FloatVariable& b = getInVal<FloatVariable>("B");
+	ImGui::Text("A %f", a.value);
+	ImGui::Text("B %f", b.value);
+	if (a.value == b.value)
+		ImGui::Text("Res True");
+	else
+		ImGui::Text("Res False");
+}
+
+void EqualFloatNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void EqualFloatNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<FloatVariable>("A");
+	const auto& b = getInVal<FloatVariable>("B");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} = {} == {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = {} == {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> EqualFloatNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("A", ImFlow::ConnectionFilter::SameType(), FloatVariable(0.f)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<FloatVariable>>("B", ImFlow::ConnectionFilter::SameType(), FloatVariable(2.f)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+
+
+NotGateNode::NotGateNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const BoolVariable& a = getInVal<BoolVariable>("A");
+		std::string name = (a.IsConstant()) ? "" : outName;
+
+		return BoolVariable(!a.value, name);
+
+		});
+
+}
+
+NotGateNode::NotGateNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :NotGateNode(rend, style) {}
+
+
+void NotGateNode::draw() {
+	const BoolVariable& a = getInVal<BoolVariable>("A");
+
+	if (!a.value)
+	{
+		ImGui::Text("A False");
+		ImGui::Text("Res True");
+	}
+	else
+	{
+		ImGui::Text("A True");
+		ImGui::Text("Res False");
+	}
+}
+void NotGateNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void NotGateNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<BoolVariable>("A");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} = !{};", out.GetFormattedName(proto), a.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = !{};", out.GetFormattedName(proto), a.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> NotGateNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("A", ImFlow::ConnectionFilter::SameType(), BoolVariable(false)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+AndGateNode::AndGateNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const BoolVariable& a = getInVal<BoolVariable>("A");
+		const BoolVariable& b = getInVal<BoolVariable>("B");
+		std::string name = (a.IsConstant() && b.IsConstant()) ? "" : outName;
+
+		return BoolVariable(a.value == b.value, name);
+
+		});
+
+}
+
+AndGateNode::AndGateNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :AndGateNode(rend, style) {}
+
+
+void AndGateNode::draw() {
+	const BoolVariable& a = getInVal<BoolVariable>("A");
+	const BoolVariable& b = getInVal<BoolVariable>("B");
+	ImGui::Text("A %s", a.value ? "True" : "False");
+	ImGui::Text("A %s", b.value ? "True" : "False");
+
+	if (a.value == b.value)
+		ImGui::Text("Res True");
+	else
+		ImGui::Text("Res False");
+}
+
+void AndGateNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void AndGateNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<BoolVariable>("A");
+	const auto& b = getInVal<BoolVariable>("B");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} = {} == {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = {} == {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> AndGateNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("A", ImFlow::ConnectionFilter::SameType(), BoolVariable(0.f)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("B", ImFlow::ConnectionFilter::SameType(), BoolVariable(2.f)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+OrGateNode::OrGateNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const BoolVariable& a = getInVal<BoolVariable>("A");
+		const BoolVariable& b = getInVal<BoolVariable>("B");
+		std::string name = (a.IsConstant() && b.IsConstant()) ? "" : outName;
+
+		return BoolVariable(a.value || b.value, name);
+
+		});
+
+}
+
+OrGateNode::OrGateNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :OrGateNode(rend, style) {}
+
+
+void OrGateNode::draw() {
+	const BoolVariable& a = getInVal<BoolVariable>("A");
+	const BoolVariable& b = getInVal<BoolVariable>("B");
+	ImGui::Text("A %s", a.value ? "True" : "False");
+	ImGui::Text("A %s", b.value ? "True" : "False");
+
+	if (a.value || b.value)
+		ImGui::Text("Res True");
+	else
+		ImGui::Text("Res False");
+}
+
+void OrGateNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void OrGateNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<BoolVariable>("A");
+	const auto& b = getInVal<BoolVariable>("B");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} = {} || {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = {} || {};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> OrGateNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("A", ImFlow::ConnectionFilter::SameType(), BoolVariable(0.f)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("B", ImFlow::ConnectionFilter::SameType(), BoolVariable(2.f)));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+EqualStringNode::EqualStringNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<BoolVariable>("Res")->behaviour([this, outName]() {
+
+		const StringVariable& a = getInVal<StringVariable>("A");
+		const StringVariable& b = getInVal<StringVariable>("B");
+		std::string name = (a.IsConstant() && b.IsConstant()) ? "" : outName;
+
+		return BoolVariable(a.value == b.value, name);
+
+		});
+
+}
+
+EqualStringNode::EqualStringNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :EqualStringNode(rend, style) {}
+
+
+void EqualStringNode::draw() {
+	const StringVariable& a = getInVal<StringVariable>("A");
+	const StringVariable& b = getInVal<StringVariable>("B");
+	ImGui::Text("A %s", a.value.c_str());
+	ImGui::Text("B %s", b.value.c_str());
+	if (a.value == b.value)
+		ImGui::Text("Res True");
+	else
+		ImGui::Text("Res False");
+}
+
+void EqualStringNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void EqualStringNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<BoolVariable>("Res")->val();
+	const auto& a = getInVal<StringVariable>("A");
+	const auto& b = getInVal<StringVariable>("B");
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+			proto.codeLines.push_back(std::format("{} !strcmp({}, {});", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		else
+			proto.codeLines.push_back(std::format("bool {} = !strcmp({}, {});", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto)));
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> EqualStringNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<StringVariable>>("A", ImFlow::ConnectionFilter::SameType(), StringVariable("Default String")));
+	info.push_back(std::make_shared<ImFlow::InPinProto<StringVariable>>("B", ImFlow::ConnectionFilter::SameType(), StringVariable("Default String")));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<BoolVariable>>("Res"));
+	return info;
+}
+
+
+ConditionalStringNode::ConditionalStringNode(RenderInstance& rend, ImFlow::StyleManager& style) :RuiBaseNode(name, category, GetPinInfo(), rend, style) {
+	std::string outName = Variable::UniqueName();
+	getOut<StringVariable>("Res")->behaviour([this, outName]() {
+
+		const BoolVariable& a = getInVal<BoolVariable>("A");
+		const StringVariable& b = getInVal<StringVariable>("B");
+		const StringVariable& c = getInVal<StringVariable>("C");
+
+		std::string name = (a.IsConstant() && b.IsConstant() && c.IsConstant()) ? "" : outName;
+
+		if (a.value)
+			return StringVariable(b.value, name);
+		else
+			return StringVariable(c.value, name);
+
+		});
+
+}
+
+ConditionalStringNode::ConditionalStringNode(RenderInstance& rend, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj) :ConditionalStringNode(rend, style) {}
+
+
+void ConditionalStringNode::draw() {
+	const BoolVariable& a = getInVal<BoolVariable>("A");
+
+	const StringVariable& b = getInVal<StringVariable>("B");
+	const StringVariable& c = getInVal<StringVariable>("C");
+
+	if (a.value)
+		ImGui::Text("In True");
+	else
+		ImGui::Text("In False");
+	ImGui::Text("True %s", b.value.c_str());
+	ImGui::Text("False %s", c.value.c_str());
+
+}
+
+void ConditionalStringNode::Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) {
+	obj.AddMember("Name", name, allocator);
+	obj.AddMember("Category", category, allocator);
+	RuiBaseNode::Serialize(obj, allocator);
+}
+
+void ConditionalStringNode::Export(RuiExportPrototype& proto) {
+	const auto& out = getOut<StringVariable>("Res")->val();
+	const auto& a = getInVal<BoolVariable>("A");
+	const auto& b = getInVal<StringVariable>("B");
+	const auto& c = getInVal<StringVariable>("C");
+
+	ExportElement<std::string> ele;
+	ele.dependencys = { a.name,b.name, c.name };
+	ele.identifier = out.name;
+	ele.callback = [out, a, b, c](RuiExportPrototype& proto) {
+		if (proto.varsInDataStruct.contains(out.name))
+		{
+			proto.codeLines.push_back(std::format("{} = {}?{}:{};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto), c.GetFormattedName(proto)));
+
+		}
+		else
+			proto.codeLines.push_back(std::format("const char* {} = {}?{}:{};", out.GetFormattedName(proto), a.GetFormattedName(proto), b.GetFormattedName(proto), c.GetFormattedName(proto)));
+
+		};
+	proto.codeElements.push_back(ele);
+}
+
+std::vector<std::shared_ptr<ImFlow::PinProto>> ConditionalStringNode::GetPinInfo() {
+	std::vector<std::shared_ptr<ImFlow::PinProto>> info;
+	info.push_back(std::make_shared<ImFlow::InPinProto<BoolVariable>>("A", ImFlow::ConnectionFilter::SameType(), BoolVariable(false)));
+	info.push_back(std::make_shared<ImFlow::InPinProto<StringVariable>>("B", ImFlow::ConnectionFilter::SameType(), StringVariable("Default Text")));
+	info.push_back(std::make_shared<ImFlow::InPinProto<StringVariable>>("C", ImFlow::ConnectionFilter::SameType(), StringVariable("Default Test")));
+	info.push_back(std::make_shared<ImFlow::OutPinProto<StringVariable>>("Res"));
+	return info;
+}
+
+void AddConditionalNodes(NodeEditor& editor) {
+
+	editor.AddNodeType<GreaterNode>();
+	editor.AddNodeType<LessNode>();
+	editor.AddNodeType<ConditionalFloatNode>();
+	editor.AddNodeType<EqualFloatNode>();
+	editor.AddNodeType<AndGateNode>();
+	editor.AddNodeType<NotGateNode>();
+	editor.AddNodeType<OrGateNode>();
+	editor.AddNodeType<EqualStringNode>();
+	editor.AddNodeType<ConditionalStringNode>();
+
+}

--- a/SERE/Nodes/ConditionalNodes.h
+++ b/SERE/Nodes/ConditionalNodes.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "RuiNodeEditor/RuiNodeEditor.h"
+
+
+class GreaterNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "Greater Than";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit GreaterNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit GreaterNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class LessNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "Less Than";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit LessNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit LessNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class ConditionalFloatNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "Conditional (Float)";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit ConditionalFloatNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit ConditionalFloatNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class EqualFloatNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "Equal (Float)";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit EqualFloatNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit EqualFloatNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class NotGateNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "NOT";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit NotGateNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit NotGateNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class AndGateNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "AND";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit AndGateNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit AndGateNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class OrGateNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "OR";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit OrGateNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit OrGateNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class EqualStringNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "Equal (String)";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit EqualStringNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit EqualStringNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+class ConditionalStringNode : public RuiBaseNode
+{
+public:
+	static inline std::string name = "Conditional (String)";
+	static inline std::string category = "Conditionals";
+private:
+
+
+public:
+	explicit ConditionalStringNode(RenderInstance& prot, ImFlow::StyleManager& style);
+	explicit ConditionalStringNode(RenderInstance& prot, ImFlow::StyleManager& style, rapidjson::GenericObject<false, rapidjson::Value> obj);
+	void draw() override;
+	void Serialize(rapidjson::GenericValue<rapidjson::UTF8<>>& obj, rapidjson::Document::AllocatorType& allocator) override;
+	void Export(RuiExportPrototype& proto) override;
+
+	static std::vector<std::shared_ptr<ImFlow::PinProto>> GetPinInfo();
+};
+
+void AddConditionalNodes(NodeEditor& editor);

--- a/SERE/RuiNodeEditor/RuiNodeEditor.cpp
+++ b/SERE/RuiNodeEditor/RuiNodeEditor.cpp
@@ -12,6 +12,7 @@
 #include "Nodes/SplitMergeNodes.h"
 #include "Nodes/MathNodes.h"
 #include "Nodes/GlobalNodes.h"
+#include "Nodes/ConditionalNodes.h"
 
 #include "Thirdparty/rapidjson/istreamwrapper.h"
 #include "ThirdParty/rapidjson/prettywriter.h"
@@ -340,7 +341,9 @@ void NodeEditor::SetStyles(ImFlow::StyleManager& styles) {
 	styles.AddNodeStlye(
 		"Global", 
 		std::make_shared<ImFlow::NodeStyle>(IM_COL32(57,17,132,255),ImColor(233,241,244,255),6.5f));
-
+	styles.AddNodeStlye(
+		"Conditionals",
+		std::make_shared<ImFlow::NodeStyle>(IM_COL32(173, 74, 17, 255), ImColor(233, 241, 244, 255), 6.5f));
 	
 	auto errorNodeStyle = std::make_shared<ImFlow::NodeStyle>(IM_COL32(173,25,17,255),ImColor(233,241,244,255),6.5f);
 	errorNodeStyle->bg = IM_COL32(132,23,17,255);

--- a/SERE/SERE.cpp
+++ b/SERE/SERE.cpp
@@ -23,6 +23,7 @@
 #include "Nodes/RenderJobNodes.h"
 #include "Nodes/SplitMergeNodes.h"
 #include "Nodes/TransformNodes.h"
+#include "Nodes/ConditionalNodes.h"
 
 #include "ThirdParty/nativefiledialog-extended/src/include/nfd.hpp"
 
@@ -256,6 +257,7 @@ int main(int, char**)
     AddRenderNodes(nodeEdit);
     AddSplitMergeNodes(nodeEdit);
     AddTransformNodes(nodeEdit);
+    AddConditionalNodes(nodeEdit);
 
     while (!done)
     {


### PR DESCRIPTION
	Add the following Conditional/Logic nodes along with a new category of nodes in the selector

Greater than Node
Less than Node

These output true depending on wether A is less/more then B

ConditionalFloatNode
ConditionalStringNode

Outputs either float/string a or b depending on input bool

EqualFloatNode
EqualStringNode

compares string/float and outputs true of equal

AndGateNode
NotGateNode
OrGateNode

basic logic gates, uses bools outputs bools